### PR TITLE
improved config_to_equation task; We assume now that the featuremodel pool…

### DIFF
--- a/ape/container_mode/utils.py
+++ b/ape/container_mode/utils.py
@@ -1,7 +1,12 @@
 from __future__ import print_function, unicode_literals
-import git
-import xml.etree.ElementTree
+
+import json
+import os
 import os.path
+import xml.etree.ElementTree
+
+import featuremonkey
+import git
 
 
 def get_repo_name(repo_dir):
@@ -41,7 +46,6 @@ def get_feature_order_constraints(container_dir):
     :param container_dir: the container dir.
     :return: dict
     """
-    import json
 
     file_path = os.path.join(container_dir, '_lib/featuremodel/productline/feature_order.json')
     with open(file_path, 'r') as f:
@@ -52,14 +56,34 @@ def get_feature_order_constraints(container_dir):
 
 def get_features_from_equation(container_dir, product_name):
     """
-    Takes the container dir and the product name and returns the list of features.
-    :param container_dir: path of the container dir
-    :param product_name: name of the product
     :return: list of strings, each representing one feature
     """
-    import featuremonkey
     file_path = os.path.join(container_dir, 'products', product_name, 'product.equation')
     return featuremonkey.get_features_from_equation_file(file_path)
+
+
+def _get_featuremodel_path(container_dir):
+    """
+    Either takes default path (relative to ape root) or, if set, the FEATUREMODEL_POOL_PATH.
+    This path should be absolute and set in your initenv file, e.g. like that:
+
+        export FEATUREMODEL_POOL_PATH=$PYTHONPATH:`/foo/bar/featuremodel`
+
+    We assume that the featuremodel pool is placed top level in the ape root and is called "featuremodel".
+    Reason: the featurepool model should be considerable for any project in your ape root and
+    therefore you only need it once, not separated in every container.
+    :return:
+    """
+    featuremodel_path = os.path.abspath(os.path.join(os.environ.get('APE_ROOT_DIR'), 'featuremodel'))
+    env_path = os.environ.get('FEATUREMODEL_POOL_PATH')
+    if env_path:
+        featuremodel_path = env_path
+
+    # still try a fallback to the featuremodel pool in the _lib dir in case something is wrong the the given paths
+    if not os.path.exists(featuremodel_path) or not os.path.isdir(featuremodel_path):
+        featuremodel_path = os.path.join(container_dir, '_lib/featuremodel')
+
+    return featuremodel_path
 
 
 def get_feature_ide_paths(container_dir, product_name):
@@ -71,12 +95,13 @@ def get_feature_ide_paths(container_dir, product_name):
     :return: object with divert path attributes
     """
     repo_name = get_repo_name(container_dir)
+    featuremodel_path = _get_featuremodel_path(container_dir)
 
     class Paths(object):
-        feature_order_json = os.path.join(container_dir, '_lib/featuremodel/productline/feature_order.json')
-        model_xml_path = os.path.join(container_dir, '_lib/featuremodel/productline/model.xml')
-        config_file_path = os.path.join(container_dir, '_lib/featuremodel/productline/products/', repo_name, product_name, 'product.equation.config')
+        feature_order_json = os.path.join(featuremodel_path, 'productline/feature_order.json')
+        model_xml_path = os.path.join(featuremodel_path, 'productline/model.xml')
+        config_file_path = os.path.join(featuremodel_path, 'productline/products/', repo_name, product_name, 'product.equation.config')
         equation_file_path = os.path.join(container_dir, 'products', product_name, 'product.equation')
-        product_spec_path = os.path.join(container_dir, '_lib/featuremodel/productline/products/', repo_name, 'product_spec.json')
+        product_spec_path = os.path.join(featuremodel_path, 'productline/products/', repo_name, 'product_spec.json')
 
     return Paths

--- a/ape/exceptions.py
+++ b/ape/exceptions.py
@@ -1,5 +1,3 @@
-
-
 class EnvironmentIncomplete(Exception):
     pass
 

--- a/ape/installtools/pypath.py
+++ b/ape/installtools/pypath.py
@@ -1,3 +1,6 @@
+from __future__ import print_function, unicode_literals
+
+import codecs
 import os
 import json
 
@@ -9,7 +12,7 @@ def get_extra_pypath(container_name=None):
     if not os.path.exists(paths_file):
         raise Exception('ERROR: _lib/paths.json does not exist. Did you run ``ape install_container``?')
     else:
-        with open(paths_file, 'r') as f:
+        with codecs.open(paths_file, 'r') as f:
             return json.loads(f.read())
 
 
@@ -19,4 +22,4 @@ def generate_pypath_for_initenv():
 
 
 if __name__ == '__main__':
-    print(generate_pypath_for_initenv(), end='')
+    print(generate_pypath_for_initenv())

--- a/ape/installtools/venv.py
+++ b/ape/installtools/venv.py
@@ -1,7 +1,9 @@
-from subprocess import check_call
+from __future__ import print_function, unicode_literals
+
 import glob
 import os
 import sys
+from subprocess import check_call
 
 
 class VirtualEnv(object):

--- a/ape/main.py
+++ b/ape/main.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import argparse
 import inspect
 import importlib


### PR DESCRIPTION
…is placed top level in the ape root and is called "featuremodel".

Reason: the featurepool model should be considerable for any project in your ape root and therefore you only need it once, not separated in every container.

The path can be customized using the FEATUREMODEL_POOL_PATH environment variable.

Additionally adjusted some code for python3/pep8.